### PR TITLE
redirect_uri is mandatory field for get_access_token

### DIFF
--- a/uberapi.py
+++ b/uberapi.py
@@ -170,6 +170,7 @@ class UberAPI(object):
                                   client_id=self.client_id,
                                   client_secret=self.client_secret,
                                   grant_type='authorization_code',
+                                  redirect_uri=self.redirect_uri,
                                   code=code)
 
     def refresh_token(self, refresh_token):


### PR DESCRIPTION
though it's not mentioned anywhere in Uber API's documentations, but `redirect_uri` is mandatory parameter for `get_access_token`. if it's not supplied it throws access denied error.

http://stackoverflow.com/a/33601604